### PR TITLE
Fixes #282

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Webtool/instance/
 .ipynb_checkpoints
 Paper/
 **/NotionExport/
+**/newevent.py
+**/full-properties.json


### PR DESCRIPTION
Started gitignoring sensitive files. They contain info about Notion that we don't want to be on the repo.