### PR TITLE
Added new email address. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository hosts the data and code for the [GRBSN webtool](https://grbsn.wa
 
 The GRBSN webtool was created by Gabriel Finneran, Laura Cotter and Antonio Martin-Carrillo at University College Dublin. An in depth look at the tool can be found in this [paper](https://arxiv.org/abs/2411.08866).
 
-To get in touch please email Gabriel Finneran at gabriel.finneran@ucdconnect.ie
+To get in touch please email Gabriel Finneran at grbsnwebtool@gmail.com
 
 # Citing and acknowledging the GRBSN webtool
 If your work has made use of the GRBSN webtool, please cite [this paper](https://ui.adsabs.harvard.edu/abs/2024arXiv241108866F/abstract). We would also appreciate if you could add the following acknowledgement (or similar) to your work:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ The following versions of the GRBSN webtool are receiving active support.
 
 ## Reporting a Vulnerability
 
-You should report security vulnerabilities by emailing gabfin15@gmail.com.
+You should report security vulnerabilities by emailing grbsnwebtool@gmail.com.

--- a/Webtool/templates/base.html
+++ b/Webtool/templates/base.html
@@ -51,7 +51,7 @@
 
     <!-- Contact -->
 
-    <a class="nav-link" href="mailto:gabriel.finneran@ucdconnect.ie">
+    <a class="nav-link" href="mailto:grbsnwebtool@gmail.com">
         <i class="fas fa-envelope"></i> Contact
     </a>
 

--- a/Webtool/templates/docs.html
+++ b/Webtool/templates/docs.html
@@ -63,7 +63,7 @@
 		<b>Contact</b>
 	</h2>
 
-	<p><b>Gabriel Finneran:</b> gabriel.finneran@ucdconnect.ie </p>
+	<p><b>Gabriel Finneran:</b> grbsnwebtool@gmail.com </p>
 	<p>School of Physics, O’Brien Centre for Science North, University College Dublin, Belfield, Dublin 4,
 		Ireland
 	<p>


### PR DESCRIPTION
There is a new email address for the tool: grbsnwebtool@gmail.com. Fixes #336 